### PR TITLE
Fix crash on record_login() before auth cached

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -290,7 +290,11 @@ sauth.auth_handler = {
 	record_login = function(name)
 		assert(type(name) == 'string')
 		update_login(name)
-		auth_table[name].last_login = os.time()
+		
+		local auth = auth_table[name]
+		if auth then
+			auth.last_login = os.time()
+		end
 		return true
 	end,
 	name_search = function(name)


### PR DESCRIPTION
Not entirely sure that this is the correct fix for the problem. I've added [password-less logins](https://github.com/ShadowNinja/minetest-irc_commands/pull/8) to irc_commands which results in `record_login` being called without first calling check password (which loads the auth into the cache when using sauth). This works in builtin but not sauth.

This change only updates the cache if it is already cached, the new login time should be retrieved from the database on next get_privileges or whatever

Untested, will deploy to my server later

